### PR TITLE
Renumbering and Supported elements section added to the documentation (Readme.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Grid(elements, nodes, facesets=facesets, cellsets=cellsets)
 
 ## Elements numberimg & Supported elements
 
-`Ferrite` might have a different element node-numbering scheme if compared to Gmsh. For correct portability of a mesh from Gmsh, it is important to transform `Gmsh` numbering in the one that Ferrite is expecting. Having the same numbering is important because the numbering provides information about which basis function is placed at each position, as well as the orientation of the elements. 
+Ferrite might have a different element node-numbering scheme if compared to Gmsh. For correct portability of a mesh from Gmsh, it is important to transform Gmsh numbering in the one that Ferrite is expecting. Having the same numbering is important because the numbering provides information about which basis function is placed at each position, as well as the orientation of the elements. 
 
 By default `FerriteGmsh` supports all Ferrite elements in which the numbering is the same to the one used in Gmsh.
 
@@ -103,4 +103,4 @@ In the particular case of the QuadraticQuadrilateral, the numbering used in `Fer
 If the numbering does not match like for example in the `QuadraticTetrahedron` an specific method for the function [translate_elements](https://github.com/koehlerson/FerriteGmsh.jl/blob/6682d9d4d95189f4799da19690b8ff0f18a9e177/src/FerriteGmsh.jl#L21-L36) has to be created. In this method, the correct numbering is specified.
 
 ### Elements supported (summary):
-With the elements supported by default and specefic `translate_elements` methods (for QuadraticTetrahedron and 3D Serendipity), all the linear and quadratic elements available in `Ferrite` are already supported by `FerriteGmsh`.
+With the elements supported by default and specific `translate_elements` methods (for QuadraticTetrahedron and 3D Serendipity), all the linear and quadratic elements available in `Ferrite` are already supported by `FerriteGmsh`.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,45 @@ gmsh.finalize()
 Grid(elements, nodes, facesets=facesets, cellsets=cellsets)
 ```
 
+## Elements numberimg & Supported elements
+
+`Ferrite` might have a different element node-numbering scheme if compared to Gmsh. For correct portability of a mesh from Gmsh, it is important to transform `Gmsh` numbering in the one that Ferrite is expecting. Having the same numbering is important because the numbering provides information about which basis function is placed at each position, as well as the orientation of the elements. 
+
+By default `FerriteGmsh` supports all Ferrite elements in which the numbering is the same to the one used in Gmsh.
+
+To check the numbering used in Ferrite, we could for example generate a grid with a single element, for a QuadraticQuadrilateral that would be:
+
+```julia
+using Ferrite
+grid =  generate_grid(QuadraticQuadrilateral,(1,1))
+```
+
+Accessing the cells of that element:
+
+```julia
+julia> grid.cells
+1-element Vector{QuadraticQuadrilateral}: 
+QuadraticQuadrilateral((1, 3, 9, 7, 2, 6, 8, 4, 5))
+```
+where the numbers refers to the global nodes ids, which can be easily visualized in the following manner using the package [FerriteVis](https://github.com/koehlerson/FerriteVis.jl).
+
+
+```julia
+using Ferrite
+using FerriteVis
+
+grid =  generate_grid(QuadraticQuadrilateral,(1,1))
+
+FerriteVis.wireframe(grid,markersize=14,strokewidth=20,textsize = 25, nodelabels=true,celllabels=true)
+```
+![Imgur](https://i.imgur.com/58OCFgo.png)
+
+The Ferrite numbering `(1, 3, 9, 7, 2, 6, 8, 4, 5)` would have to match the numbering of Gmsh (see [gmsh docs](https://gmsh.info/doc/texinfo/gmsh.html#Node-ordering)).
+
+In the particular case of the QuadraticQuadrilateral, the numbering used in `Ferrite` and the numbering used in Gmsh matches, then as it was anticipated this type of element would be supported through the default method for [translate_elements](https://github.com/koehlerson/FerriteGmsh.jl/blob/6682d9d4d95189f4799da19690b8ff0f18a9e177/src/FerriteGmsh.jl#L17-L19).
+
+
+If the numbering does not match like for example in the `QuadraticTetrahedron` an specific method for the function [translate_elements](https://github.com/koehlerson/FerriteGmsh.jl/blob/6682d9d4d95189f4799da19690b8ff0f18a9e177/src/FerriteGmsh.jl#L21-L36) has to be created. In this method, the correct numbering is specified.
+
+### Elements supported (summary):
+With the elements supported by default and specefic `translate_elements` methods (for QuadraticTetrahedron and 3D Serendipity), all the linear and quadratic elements available in `Ferrite` are already supported by `FerriteGmsh`.


### PR DESCRIPTION
With that pull request a section describing differences in numbering between Gmsh and Ferrite in addition to the already supported elements in FerriteGmsh is added to the Readme.md file. 